### PR TITLE
adding support for icon-rotate and icon-allow-overlap in mapbox

### DIFF
--- a/src/traces/scattermapbox/attributes.js
+++ b/src/traces/scattermapbox/attributes.js
@@ -87,6 +87,24 @@ module.exports = overrideAll({
                 'are only available for *circle* symbols.'
             ].join(' ')
         },
+        angle: {
+            valType: 'number',
+            dflt: null,
+            role: 'style',
+            arrayOk: true,
+            description: [
+                'Sets the marker angle.'
+            ].join(' ')
+        },
+        allowoverlap: {
+            valType: 'boolean',
+            dflt: false,
+            role: 'style',
+            arrayOk: false,
+            description: [
+                'Flag to allow symbols to overlap'
+            ].join(' ')
+        },
         opacity: markerAttrs.opacity,
         size: markerAttrs.size,
         sizeref: markerAttrs.sizeref,

--- a/src/traces/scattermapbox/defaults.js
+++ b/src/traces/scattermapbox/defaults.js
@@ -43,6 +43,9 @@ module.exports = function supplyDefaults(traceIn, traceOut, defaultColor, layout
     if(subTypes.hasMarkers(traceOut)) {
         handleMarkerDefaults(traceIn, traceOut, defaultColor, layout, coerce, {noLine: true});
 
+        coerce('marker.allowoverlap');
+        coerce('marker.angle');
+
         // array marker.size and marker.color are only supported with circles
         var marker = traceOut.marker;
         if(marker.symbol !== 'circle') {

--- a/test/image/mocks/mapbox_angles.json
+++ b/test/image/mocks/mapbox_angles.json
@@ -41,7 +41,9 @@
           "monument",
           "harbor",
           "music"
-        ]
+        ],
+        "angle": [-45, 45, 0],
+        "allowoverlap":true
       },
       "subplot": "mapbox2"
     }


### PR DESCRIPTION
Added ability to specify an angle to rotate symbols in scattermapbox.

This uses the (icon-rotate)[https://docs.mapbox.com/mapbox-gl-js/style-spec/layers/#layout-symbol-icon-rotate] from mapbox. Also added the ability to allow icons to overlap.

Note sure who to tag to review ... Tagging @jmmease since you were part of the [discussion on symbols](https://community.plot.ly/t/solved-symbol-changes-not-showing-up-with-scattermapbox/16381) on the plotly community page

Question: once this is merged, what's needed to ensure that the plotly.py gets the update? are the attributes.js enough to define the schema for it to be recognized as a valid property?